### PR TITLE
Add support for git+ssh git url prefix

### DIFF
--- a/urls.go
+++ b/urls.go
@@ -34,6 +34,7 @@ var (
 	Transports = NewTransportSet(
 		"ssh",
 		"git",
+		"git+ssh",
 		"http",
 		"https",
 		"ftp",

--- a/urls_test.go
+++ b/urls_test.go
@@ -15,17 +15,17 @@ type Test struct {
 
 type Result struct {
 	Transport string
-	User string
-	Host string
-	Path string
+	User      string
+	Host      string
+	Path      string
 }
 
 func NewResult(transport, user, host, path string) *Result {
 	return &Result{
 		Transport: transport,
-		User: user,
-		Host: host,
-		Path: path,
+		User:      user,
+		Host:      host,
+		Path:      path,
 	}
 }
 
@@ -44,7 +44,7 @@ func ResultFromURL(u *url.URL) *Result {
 	)
 }
 
-func init (){
+func init() {
 	// https://www.kernel.org/pub/software/scm/git/docs/git-clone.html
 	tests = []*Test{
 		&Test{

--- a/urls_test.go
+++ b/urls_test.go
@@ -112,6 +112,10 @@ func init() {
 			NewResult("ssh", "", "host.xz", "/path/to/repo.git/"),
 		},
 		&Test{
+			"git+ssh://host.xz/path/to/repo.git/",
+			NewResult("git+ssh", "", "host.xz", "/path/to/repo.git/"),
+		},
+		&Test{
 			"/path/to/repo.git/",
 			NewResult("file", "", "", "/path/to/repo.git/"),
 		},


### PR DESCRIPTION
We have seen a number of urls formatted with the git+ssh prefix at Sourcegraph, and given that the git CLI accepts this prefix, I thought I'd add support for it.

Would appreciate any feedback on the changes/ I wasn't able to find the document that explicitly allows the git+ssh prefix but given the behavior of the git CLI and the existence of these git+ssh links, it seemed like an adequate reason to add support.

Separately, there was a formatting error on urls_test.go which `go fmt` took care of.
