### PR TITLE
Improve regex for scp syntax that allows special characters

### DIFF
--- a/urls.go
+++ b/urls.go
@@ -29,7 +29,8 @@ import (
 )
 
 var (
-	scpSyntax = regexp.MustCompile(`([a-z]+@)?([a-z\.]+):([a-z/\.]+)`)
+	// scpSyntax was modified from https://golang.org/src/cmd/go/vcs.go.
+	scpSyntax = regexp.MustCompile(`^([a-zA-Z0-9_]+@)?([a-zA-Z0-9._-]+):(.*)$`)
 	// Transports is a set of known Git URL schemes.
 	Transports = NewTransportSet(
 		"ssh",

--- a/urls_test.go
+++ b/urls_test.go
@@ -56,6 +56,10 @@ func init (){
 			NewResult("ssh", "", "host.xz", "/path/to/repo.git/"),
 		},
 		&Test{
+			"host.xz:path/to/repo-with_specials.git/",
+			NewResult("ssh", "", "host.xz", "/path/to/repo-with_specials.git/"),
+		},
+		&Test{
 			"git://host.xz/path/to/repo.git/",
 			NewResult("git", "", "host.xz", "/path/to/repo.git/"),
 		},


### PR DESCRIPTION
Specials characters like '-' and '_', which are valid in URI's for git
repositories, were getting stripped and resulting in truncated URI
paths.

By slightly modifying the scp regex used in vcs.go, this commit adds
support for these characters and adds a test to ensure that future
changes don't result in a regression.
