### PR TITLE
Fix edge case in Parse method.

### DIFF
--- a/urls.go
+++ b/urls.go
@@ -96,7 +96,7 @@ func ParseScp(rawurl string) (u *url.URL, err error) {
 		u.Scheme = "ssh"
 		u.User = url.User(strings.TrimRight(match[1], "@"))
 		u.Host = match[2]
-		u.Path = fmt.Sprintf("/%s", match[3])
+		u.Path = fmt.Sprintf("/%s", strings.TrimLeft(match[3], "/"))
 	} else {
 		err = fmt.Errorf("no scp URL found in %q", rawurl)
 	}


### PR DESCRIPTION
Fixes case where git@<host>:/<URI> -> ssh://git@<host>//URI.
