### PR TITLE
Correct handling of scp paths

### DIFF
--- a/urls.go
+++ b/urls.go
@@ -96,7 +96,7 @@ func ParseScp(rawurl string) (u *url.URL, err error) {
 		u.Scheme = "ssh"
 		u.User = url.User(strings.TrimRight(match[1], "@"))
 		u.Host = match[2]
-		u.Path = fmt.Sprintf("/%s", match[3])
+		u.Path = match[3]
 	} else {
 		err = fmt.Errorf("no scp URL found in %q", rawurl)
 	}

--- a/urls_test.go
+++ b/urls_test.go
@@ -30,15 +30,19 @@ func init() {
 	tests = []*Test{
 		NewTest(
 			"user@host.xz:path/to/repo.git/",
-			"ssh", "user", "host.xz", "/path/to/repo.git/",
+			"ssh", "user", "host.xz", "path/to/repo.git/",
 		),
 		NewTest(
 			"host.xz:path/to/repo.git/",
+			"ssh", "", "host.xz", "path/to/repo.git/",
+		),
+		NewTest(
+			"host.xz:/path/to/repo.git/",
 			"ssh", "", "host.xz", "/path/to/repo.git/",
 		),
 		NewTest(
 			"host.xz:path/to/repo-with_specials.git/",
-			"ssh", "", "host.xz", "/path/to/repo-with_specials.git/",
+			"ssh", "", "host.xz", "path/to/repo-with_specials.git/",
 		),
 		NewTest(
 			"git://host.xz/path/to/repo.git/",


### PR DESCRIPTION
Previously, we converted relative paths into absolute paths (and
unintentionally threw an extra leading slash on already absolute paths).
The following two examples are not equivalent:

```
host.xz:path/to/repo.git
host.xz:/path/to/repo.git
```

We no longer treat them as such. Instead, relative paths come out the
other side of Parse still relative, and absolute paths are not
manipulated at all.

Update tests to match.
