### PR TITLE
Made empty user == nil

### DIFF
--- a/urls.go
+++ b/urls.go
@@ -81,9 +81,6 @@ func ParseTransport(rawurl string) (u *url.URL, err error) {
 	if err == nil && !Transports.Valid(u.Scheme) {
 		err = fmt.Errorf("scheme %q is not a valid transport", u.Scheme)
 	}
-	if u.User == nil {
-		u.User = url.User("")
-	}
 	return u, err
 }
 
@@ -93,8 +90,13 @@ func ParseScp(rawurl string) (u *url.URL, err error) {
 	match := scpSyntax.FindAllStringSubmatch(rawurl, -1)
 	if len(match) > 0 {
 		match := match[0]
+		user := strings.TrimRight(match[1], "@")
+		var userinfo *url.Userinfo
+		if user != "" {
+			userinfo = url.User(user)
+		}
 		u.Scheme = "ssh"
-		u.User = url.User(strings.TrimRight(match[1], "@"))
+		u.User = userinfo
 		u.Host = match[2]
 		u.Path = match[3]
 	} else {
@@ -108,7 +110,6 @@ func ParseScp(rawurl string) (u *url.URL, err error) {
 func ParseLocal(rawurl string) (u *url.URL, err error) {
 	u = new(url.URL)
 	u.Scheme = "file"
-	u.User = url.User("")
 	u.Host = ""
 	u.Path = rawurl
 	return u, err

--- a/urls_test.go
+++ b/urls_test.go
@@ -14,13 +14,18 @@ type Test struct {
 }
 
 func NewTest(in, transport, user, host, path string) *Test {
+	var userinfo *url.Userinfo
+	if user != "" {
+		userinfo = url.User(user)
+	}
+
 	return &Test{
 		in: in,
 		want: &url.URL{
 			Scheme: transport,
 			Host:   host,
 			Path:   path,
-			User:   url.User(user),
+			User:   userinfo,
 		},
 	}
 }


### PR DESCRIPTION
When no user part of the URL was found, the URL was created with
user == url.User(""). This created a url.String() that was in
the format:

```
    scheme://@host/path
```

This format is incompatible with git.

This change makes the user nil when no user part of the URL exists.
This creates url.String() in the format:

```
scheme://host/path
```
