### PR TITLE
fix potential nil pointer dereference

### DIFF
--- a/urls.go
+++ b/urls.go
@@ -78,6 +78,9 @@ func Parse(rawurl string) (u *url.URL, err error) {
 // scheme is a known Git transport, ParseTransport returns an error.
 func ParseTransport(rawurl string) (u *url.URL, err error) {
 	u, err = url.Parse(rawurl)
+	if err != nil {
+		return nil, err
+	}
 	if err == nil && !Transports.Valid(u.Scheme) {
 		err = fmt.Errorf("scheme %q is not a valid transport", u.Scheme)
 	}


### PR DESCRIPTION
The behavior of `url.Parse` in the standard library is to return nil when error is non-nil (see https://github.com/golang/go/blob/34f97d28d2ff435b8ac85ad6645aaf79a5d061bd/src/net/url/url.go#L414). By not checking for `err != nil`, this introduces a potential nil pointer reference in the subsequent line, `if u.User == nil {`.
