### PR TITLE
When there is no `Userinfo` it should be set to `nil` not `url.User("")`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.5
+  - 1.11
   
 install:
   - make deps install lint test

--- a/urls.go
+++ b/urls.go
@@ -81,9 +81,6 @@ func ParseTransport(rawurl string) (u *url.URL, err error) {
 	if err == nil && !Transports.Valid(u.Scheme) {
 		err = fmt.Errorf("scheme %q is not a valid transport", u.Scheme)
 	}
-	if u.User == nil {
-		u.User = url.User("")
-	}
 	return u, err
 }
 
@@ -93,8 +90,13 @@ func ParseScp(rawurl string) (u *url.URL, err error) {
 	match := scpSyntax.FindAllStringSubmatch(rawurl, -1)
 	if len(match) > 0 {
 		match := match[0]
+		user := strings.TrimRight(match[1], "@")
+		var userinfo *url.Userinfo
+		if user != "" {
+			userinfo = url.User(user)
+		}
 		u.Scheme = "ssh"
-		u.User = url.User(strings.TrimRight(match[1], "@"))
+		u.User = userinfo
 		u.Host = match[2]
 		u.Path = match[3]
 	} else {
@@ -108,7 +110,6 @@ func ParseScp(rawurl string) (u *url.URL, err error) {
 func ParseLocal(rawurl string) (u *url.URL, err error) {
 	u = new(url.URL)
 	u.Scheme = "file"
-	u.User = url.User("")
 	u.Host = ""
 	u.Path = rawurl
 	return u, err

--- a/urls_test.go
+++ b/urls_test.go
@@ -9,24 +9,29 @@ import (
 var tests []*Test
 
 type Test struct {
-	in   string
-	want *url.URL
+	in      string
+	wantURL *url.URL
+	wantStr string // expected result of reserializing the URL; empty means same as "in".
 }
 
-func NewTest(in, transport, user, host, path string) *Test {
+func NewTest(in, transport, user, host, path, str string) *Test {
 	var userinfo *url.Userinfo
 	if user != "" {
 		userinfo = url.User(user)
 	}
+	if str == "" {
+		str = in
+	}
 
 	return &Test{
 		in: in,
-		want: &url.URL{
+		wantURL: &url.URL{
 			Scheme: transport,
 			Host:   host,
 			Path:   path,
 			User:   userinfo,
 		},
+		wantStr: str,
 	}
 }
 
@@ -36,86 +41,107 @@ func init() {
 		NewTest(
 			"user@host.xz:path/to/repo.git/",
 			"ssh", "user", "host.xz", "path/to/repo.git/",
+			"ssh://user@host.xz/path/to/repo.git/",
 		),
 		NewTest(
 			"host.xz:path/to/repo.git/",
 			"ssh", "", "host.xz", "path/to/repo.git/",
+			"ssh://host.xz/path/to/repo.git/",
 		),
 		NewTest(
 			"host.xz:/path/to/repo.git/",
 			"ssh", "", "host.xz", "/path/to/repo.git/",
+			"ssh://host.xz/path/to/repo.git/",
 		),
 		NewTest(
 			"host.xz:path/to/repo-with_specials.git/",
 			"ssh", "", "host.xz", "path/to/repo-with_specials.git/",
+			"ssh://host.xz/path/to/repo-with_specials.git/",
 		),
 		NewTest(
 			"git://host.xz/path/to/repo.git/",
 			"git", "", "host.xz", "/path/to/repo.git/",
+			"",
 		),
 		NewTest(
 			"git://host.xz:1234/path/to/repo.git/",
 			"git", "", "host.xz:1234", "/path/to/repo.git/",
+			"",
 		),
 		NewTest(
 			"http://host.xz/path/to/repo.git/",
 			"http", "", "host.xz", "/path/to/repo.git/",
+			"",
 		),
 		NewTest(
 			"http://host.xz:1234/path/to/repo.git/",
 			"http", "", "host.xz:1234", "/path/to/repo.git/",
+			"",
 		),
 		NewTest(
 			"https://host.xz/path/to/repo.git/",
 			"https", "", "host.xz", "/path/to/repo.git/",
+			"",
 		),
 		NewTest(
 			"https://host.xz:1234/path/to/repo.git/",
 			"https", "", "host.xz:1234", "/path/to/repo.git/",
+			"",
 		),
 		NewTest(
 			"ftp://host.xz/path/to/repo.git/",
 			"ftp", "", "host.xz", "/path/to/repo.git/",
+			"",
 		),
 		NewTest(
 			"ftp://host.xz:1234/path/to/repo.git/",
 			"ftp", "", "host.xz:1234", "/path/to/repo.git/",
+			"",
 		),
 		NewTest(
 			"ftps://host.xz/path/to/repo.git/",
 			"ftps", "", "host.xz", "/path/to/repo.git/",
+			"",
 		),
 		NewTest(
 			"ftps://host.xz:1234/path/to/repo.git/",
 			"ftps", "", "host.xz:1234", "/path/to/repo.git/",
+			"",
 		),
 		NewTest(
 			"rsync://host.xz/path/to/repo.git/",
 			"rsync", "", "host.xz", "/path/to/repo.git/",
+			"",
 		),
 		NewTest(
 			"ssh://user@host.xz:1234/path/to/repo.git/",
 			"ssh", "user", "host.xz:1234", "/path/to/repo.git/",
+			"",
 		),
 		NewTest(
 			"ssh://host.xz:1234/path/to/repo.git/",
 			"ssh", "", "host.xz:1234", "/path/to/repo.git/",
+			"",
 		),
 		NewTest(
 			"ssh://host.xz/path/to/repo.git/",
 			"ssh", "", "host.xz", "/path/to/repo.git/",
+			"",
 		),
 		NewTest(
 			"git+ssh://host.xz/path/to/repo.git/",
 			"git+ssh", "", "host.xz", "/path/to/repo.git/",
+			"",
 		),
 		NewTest(
 			"/path/to/repo.git/",
 			"file", "", "", "/path/to/repo.git/",
+			"file:///path/to/repo.git/",
 		),
 		NewTest(
 			"file:///path/to/repo.git/",
 			"file", "", "", "/path/to/repo.git/",
+			"",
 		),
 	}
 }
@@ -124,12 +150,15 @@ func TestParse(t *testing.T) {
 	for _, tt := range tests {
 		got, err := Parse(tt.in)
 		if err != nil {
-			t.Errorf("Parse(%q) = unexpected err %q, want %q", tt.in, err, tt.want)
+			t.Errorf("Parse(%q) = unexpected err %q, want %q", tt.in, err, tt.wantURL)
 			continue
 		}
-
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("Parse(%q) = %q, want %q", tt.in, got, tt.want)
+		if !reflect.DeepEqual(got, tt.wantURL) {
+			t.Errorf("Parse(%q) = %q, want %q", tt.in, got, tt.wantURL)
+		}
+		str := got.String()
+		if str != tt.wantStr {
+			t.Errorf("Parse(%q).String() = %q, want %q", tt.in, str, tt.wantStr)
 		}
 	}
 }

--- a/urls_test.go
+++ b/urls_test.go
@@ -14,13 +14,18 @@ type Test struct {
 }
 
 func NewTest(in, transport, user, host, path string) *Test {
+	var userinfo *url.Userinfo
+	if user != "" {
+		userinfo = url.User(user)
+	}
+
 	return &Test{
 		in: in,
 		want: &url.URL{
 			Scheme: transport,
 			Host:   host,
 			Path:   path,
-			User:   url.User(user),
+			User:   userinfo,
 		},
 	}
 }


### PR DESCRIPTION
If you parse a git URL without Userinfo and then convert it back to string you get an extra "@" symbol.

According to `net/url` library:
- `Userinfo == nil` means no user.
- `Userinfo == url.User("")` is treated as if there is a user with an empty name.

see how `url.String()` from `net/url` prints an '@' symbol when userinfo != nil: https://github.com/golang/go/blob/a49067aab6eeff36d7219142ed52cc3db4d6c1d8/src/net/url/url.go#L788

Find more details and exampes about the bug at: https://github.com/whilp/git-urls/issues/15

---

- I took this PR that solves the bug (https://github.com/whilp/git-urls/pull/11).
- Merged on master
- Extended tests to show what the PR fixes

follow up to this PR: https://github.com/whilp/git-urls/pull/11
closes issue: https://github.com/whilp/git-urls/issues/15
