### PR TITLE
support rawquery in ssh (scp) transport

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/whilp/git-urls
+
+go 1.13

--- a/urls.go
+++ b/urls.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	// scpSyntax was modified from https://golang.org/src/cmd/go/vcs.go.
-	scpSyntax = regexp.MustCompile(`^([a-zA-Z0-9_]+@)?([a-zA-Z0-9._-]+):(.*)$`)
+	scpSyntax = regexp.MustCompile(`^([a-zA-Z0-9_]+@)?([a-zA-Z0-9._-]+):([a-zA-Z0-9./._-]+)(?:\?||$)(.*)$`)
 
 	// Transports is a set of known Git URL schemes.
 	Transports = NewTransportSet(
@@ -100,11 +100,16 @@ func ParseScp(rawurl string) (*url.URL, error) {
 	if user != "" {
 		userinfo = url.User(user)
 	}
+	rawquery := ""
+	if len(m) > 3 {
+		rawquery = m[4]
+	}
 	return &url.URL{
-		Scheme: "ssh",
-		User:   userinfo,
-		Host:   m[2],
-		Path:   m[3],
+		Scheme:   "ssh",
+		User:     userinfo,
+		Host:     m[2],
+		Path:     m[3],
+		RawQuery: rawquery,
 	}, nil
 }
 

--- a/urls_test.go
+++ b/urls_test.go
@@ -3,6 +3,7 @@ package giturls
 import (
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -14,10 +15,17 @@ type Test struct {
 	wantStr string // expected result of reserializing the URL; empty means same as "in".
 }
 
-func NewTest(in, transport, user, host, path, str string) *Test {
+func NewTest(in, transport, user, host, path, str, rawquery string) *Test {
 	var userinfo *url.Userinfo
+
 	if user != "" {
-		userinfo = url.User(user)
+		if strings.Contains(user, ":") {
+			username := strings.Split(user, ":")[0]
+			password := strings.Split(user, ":")[1]
+			userinfo = url.UserPassword(username, password)
+		} else {
+			userinfo = url.User(user)
+		}
 	}
 	if str == "" {
 		str = in
@@ -26,10 +34,11 @@ func NewTest(in, transport, user, host, path, str string) *Test {
 	return &Test{
 		in: in,
 		wantURL: &url.URL{
-			Scheme: transport,
-			Host:   host,
-			Path:   path,
-			User:   userinfo,
+			Scheme:   transport,
+			Host:     host,
+			Path:     path,
+			User:     userinfo,
+			RawQuery: rawquery,
 		},
 		wantStr: str,
 	}
@@ -41,107 +50,149 @@ func init() {
 		NewTest(
 			"user@host.xz:path/to/repo.git/",
 			"ssh", "user", "host.xz", "path/to/repo.git/",
-			"ssh://user@host.xz/path/to/repo.git/",
+			"ssh://user@host.xz/path/to/repo.git/", "",
 		),
 		NewTest(
 			"host.xz:path/to/repo.git/",
 			"ssh", "", "host.xz", "path/to/repo.git/",
-			"ssh://host.xz/path/to/repo.git/",
+			"ssh://host.xz/path/to/repo.git/", "",
 		),
 		NewTest(
 			"host.xz:/path/to/repo.git/",
 			"ssh", "", "host.xz", "/path/to/repo.git/",
-			"ssh://host.xz/path/to/repo.git/",
+			"ssh://host.xz/path/to/repo.git/", "",
 		),
 		NewTest(
 			"host.xz:path/to/repo-with_specials.git/",
 			"ssh", "", "host.xz", "path/to/repo-with_specials.git/",
-			"ssh://host.xz/path/to/repo-with_specials.git/",
+			"ssh://host.xz/path/to/repo-with_specials.git/", "",
 		),
 		NewTest(
 			"git://host.xz/path/to/repo.git/",
 			"git", "", "host.xz", "/path/to/repo.git/",
-			"",
+			"", "",
 		),
 		NewTest(
 			"git://host.xz:1234/path/to/repo.git/",
 			"git", "", "host.xz:1234", "/path/to/repo.git/",
-			"",
+			"", "",
 		),
 		NewTest(
 			"http://host.xz/path/to/repo.git/",
 			"http", "", "host.xz", "/path/to/repo.git/",
-			"",
+			"", "",
 		),
 		NewTest(
 			"http://host.xz:1234/path/to/repo.git/",
 			"http", "", "host.xz:1234", "/path/to/repo.git/",
-			"",
+			"", "",
 		),
 		NewTest(
 			"https://host.xz/path/to/repo.git/",
 			"https", "", "host.xz", "/path/to/repo.git/",
-			"",
+			"", "",
 		),
 		NewTest(
 			"https://host.xz:1234/path/to/repo.git/",
 			"https", "", "host.xz:1234", "/path/to/repo.git/",
-			"",
+			"", "",
 		),
 		NewTest(
 			"ftp://host.xz/path/to/repo.git/",
 			"ftp", "", "host.xz", "/path/to/repo.git/",
-			"",
+			"", "",
 		),
 		NewTest(
 			"ftp://host.xz:1234/path/to/repo.git/",
 			"ftp", "", "host.xz:1234", "/path/to/repo.git/",
-			"",
+			"", "",
 		),
 		NewTest(
 			"ftps://host.xz/path/to/repo.git/",
 			"ftps", "", "host.xz", "/path/to/repo.git/",
-			"",
+			"", "",
 		),
 		NewTest(
 			"ftps://host.xz:1234/path/to/repo.git/",
 			"ftps", "", "host.xz:1234", "/path/to/repo.git/",
-			"",
+			"", "",
 		),
 		NewTest(
 			"rsync://host.xz/path/to/repo.git/",
 			"rsync", "", "host.xz", "/path/to/repo.git/",
-			"",
+			"", "",
 		),
 		NewTest(
 			"ssh://user@host.xz:1234/path/to/repo.git/",
 			"ssh", "user", "host.xz:1234", "/path/to/repo.git/",
-			"",
+			"", "",
 		),
 		NewTest(
 			"ssh://host.xz:1234/path/to/repo.git/",
 			"ssh", "", "host.xz:1234", "/path/to/repo.git/",
-			"",
+			"", "",
 		),
 		NewTest(
 			"ssh://host.xz/path/to/repo.git/",
 			"ssh", "", "host.xz", "/path/to/repo.git/",
-			"",
+			"", "",
 		),
 		NewTest(
 			"git+ssh://host.xz/path/to/repo.git/",
 			"git+ssh", "", "host.xz", "/path/to/repo.git/",
-			"",
+			"", "",
 		),
 		NewTest(
 			"/path/to/repo.git/",
 			"file", "", "", "/path/to/repo.git/",
-			"file:///path/to/repo.git/",
+			"file:///path/to/repo.git/", "",
 		),
 		NewTest(
 			"file:///path/to/repo.git/",
 			"file", "", "", "/path/to/repo.git/",
-			"",
+			"", "",
+		),
+		// Tests with query strings
+		NewTest(
+			"https://host.xz/organization/repo.git?ref=",
+			"https", "", "host.xz", "/organization/repo.git",
+			"", "ref=",
+		),
+		NewTest(
+			"https://host.xz/organization/repo.git?ref=test",
+			"https", "", "host.xz", "/organization/repo.git",
+			"", "ref=test",
+		),
+		NewTest(
+			"https://host.xz/organization/repo.git?ref=feature/test",
+			"https", "", "host.xz", "/organization/repo.git",
+			"", "ref=feature/test",
+		),
+		NewTest(
+			"git@host.xz:organization/repo.git?ref=test",
+			"ssh", "git", "host.xz", "organization/repo.git",
+			"ssh://git@host.xz/organization/repo.git?ref=test", "ref=test",
+		),
+		NewTest(
+			"git@host.xz:organization/repo.git?ref=feature/test",
+			"ssh", "git", "host.xz", "organization/repo.git",
+			"ssh://git@host.xz/organization/repo.git?ref=feature/test", "ref=feature/test",
+		),
+		// Tests with user+password and some with query strings
+		NewTest(
+			"https://user:password@host.xz/organization/repo.git/",
+			"https", "user:password", "host.xz", "/organization/repo.git/",
+			"", "",
+		),
+		NewTest(
+			"https://user:password@host.xz/organization/repo.git?ref=test",
+			"https", "user:password", "host.xz", "/organization/repo.git",
+			"", "ref=test",
+		),
+		NewTest(
+			"https://user:password@host.xz/organization/repo.git?ref=feature/test",
+			"https", "user:password", "host.xz", "/organization/repo.git",
+			"", "ref=feature/test",
 		),
 	}
 }


### PR DESCRIPTION
Hi Will, not sure the policy on PRs but I made some tweaks to accept RawQuery strings for the ssh transport. Hope this can help someone.

Before the update, this code did not produce a `RawQuery` output:

```go
func main() {
	a, _ := giturls.Parse("git@github.com:org/repo.git?ref=abc/123")
	fmt.Println(a, "query:", a.RawQuery)
}
```

Results before this PR:

```bash
$ go run main.go
ssh://git@github.com/org/repo.git%3Fref=abc/123 query:
```


Results with changes in the PR:
```bash
$ go run main.go
ssh://git@github.com/org/repo.git?ref=abc/123 query: ref=abc/123
```

Cheers!