### PR TITLE
Fix userinfo part of regexp

### DIFF
--- a/urls.go
+++ b/urls.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	// scpSyntax was modified from https://golang.org/src/cmd/go/vcs.go.
-	scpSyntax = regexp.MustCompile(`^([a-zA-Z0-9_]+@)?([a-zA-Z0-9._-]+):([a-zA-Z0-9./._-]+)(?:\?||$)(.*)$`)
+	scpSyntax = regexp.MustCompile(`^([a-zA-Z0-9-._~]+@)?([a-zA-Z0-9._-]+):([a-zA-Z0-9./._-]+)(?:\?||$)(.*)$`)
 
 	// Transports is a set of known Git URL schemes.
 	Transports = NewTransportSet(

--- a/urls_test.go
+++ b/urls_test.go
@@ -194,6 +194,11 @@ func init() {
 			"https", "user:password", "host.xz", "/organization/repo.git",
 			"", "ref=feature/test",
 		),
+		NewTest(
+			"user-1234@host.xz:path/to/repo.git/",
+			"ssh", "user-1234", "host.xz", "path/to/repo.git/",
+			"ssh://user-1234@host.xz/path/to/repo.git/", "",
+		),
 	}
 }
 


### PR DESCRIPTION
Unless I'm misreading rfc3986, the userinfo can contain:
ALPHA / DIGIT / "-" / "." / "_" / "~"

Github orgs are of the form "org-########", which is what I'm personally needing
to parse.