### PR TITLE
Update some Makefile things.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,3 @@ install:
 
 deps:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.3
-	go get golang.org/x/tools/cmd/cover

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ test:
 	go test -covermode=count -coverprofile=profile.cov .
 
 lint:
-	gometalinter ./...
+	golangci-lint run
 
 install:
 	go get -d -v ./... && go build -v ./...
 	gometalinter --install --update
 
 deps:
-	go get github.com/alecthomas/gometalinter
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.3
 	go get golang.org/x/tools/cmd/cover


### PR DESCRIPTION
* `github.com/alecthomas/gometalinter` is [archived and deprecated](https://github.com/alecthomas/gometalinter), so this switches over to the current community favorite  `github.com/golangci/golangci-lint`
* remove the code coverage dep, as that code is [in the golang source code now](https://pkg.go.dev/golang.org/x/tools/cmd/cover#section-readme)
* adds an empty `go.sum` for good measure